### PR TITLE
Add lifecycle tracking and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ line-length = 88
 
 [tool.pytest.ini_options]
 minversion = '6.0'
-testpaths = ['super_glitch_bot/tests']
+testpaths = ['tests']

--- a/super_glitch_bot/database/models.py
+++ b/super_glitch_bot/database/models.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
@@ -16,6 +16,9 @@ class Token:
     rugcheck_report: Dict[str, Any] = field(default_factory=dict)
     dexscreener_data: Dict[str, Any] = field(default_factory=dict)
     metadata: Dict[str, Any] = field(default_factory=dict)
+    raydium_pair: Optional[str] = None
+    active: bool = True
+    status_history: List[str] = field(default_factory=list)
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: datetime = field(default_factory=datetime.utcnow)
 

--- a/super_glitch_bot/datasources/dexscreener.py
+++ b/super_glitch_bot/datasources/dexscreener.py
@@ -1,6 +1,6 @@
 """Dexscreener API integration."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests
 
@@ -17,3 +17,11 @@ class DexScreenerSource:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         return response.json()
+
+    def get_raydium_pair(self, data: Dict[str, Any]) -> Optional[str]:
+        """Return the Raydium pair address if present."""
+        pairs = data.get("pairs", [])
+        for pair in pairs:
+            if pair.get("dex") == "Raydium" and pair.get("pairAddress"):
+                return pair["pairAddress"]
+        return None

--- a/super_glitch_bot/datasources/helius.py
+++ b/super_glitch_bot/datasources/helius.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 from typing import Any, Awaitable, Callable, List, Optional
 
 import websockets
@@ -19,6 +20,7 @@ class HeliusSource:
         self.rpc_url = rpc_url
         self.program_ids = program_ids or []
         self.on_token = on_token
+        self.logger = logging.getLogger(__name__)
 
     async def _listen(self) -> None:
         request = {
@@ -32,6 +34,7 @@ class HeliusSource:
         }
 
         async with websockets.connect(self.rpc_url) as ws:
+            self.logger.info("Listening to Helius WebSocket %s", self.rpc_url)
             await ws.send(json.dumps(request))
             while True:
                 message = await ws.recv()

--- a/super_glitch_bot/services/assessor.py
+++ b/super_glitch_bot/services/assessor.py
@@ -1,5 +1,6 @@
 """Token assessment logic."""
 
+import logging
 from typing import Any, Dict
 
 
@@ -9,6 +10,7 @@ class TokenAssessor:
     def __init__(self) -> None:
         self.min_score = 60
         self.min_liquidity = 1000.0
+        self.logger = logging.getLogger(__name__)
 
     def assess(self, token: Dict[str, Any]) -> bool:
         """Return True if the token qualifies as a gem."""
@@ -16,4 +18,12 @@ class TokenAssessor:
         liquidity = (
             token.get("dexscreener_data", {}).get("liquidity", {}).get("usd", 0.0)
         )
-        return score >= self.min_score and liquidity >= self.min_liquidity
+        result = score >= self.min_score and liquidity >= self.min_liquidity
+        self.logger.info(
+            "Assessment for %s: score=%s liquidity=%s result=%s",
+            token.get("address"),
+            score,
+            liquidity,
+            result,
+        )
+        return result

--- a/super_glitch_bot/services/monitor.py
+++ b/super_glitch_bot/services/monitor.py
@@ -1,5 +1,6 @@
 """Token monitoring services."""
 
+import logging
 from typing import Awaitable, Callable
 
 from ..datasources.helius import HeliusSource
@@ -13,7 +14,9 @@ class TokenMonitor:
     ) -> None:
         self.source = source
         self.callback = callback
+        self.logger = logging.getLogger(__name__)
 
     async def run(self) -> None:
         """Run the monitoring loop."""
+        self.logger.info("Starting token monitor")
         await self.source.start_listening(self.callback)

--- a/super_glitch_bot/services/performance_tracker.py
+++ b/super_glitch_bot/services/performance_tracker.py
@@ -1,10 +1,12 @@
 """Track token performance after signaling."""
 
-from typing import Any, Dict, List
+import logging
+from typing import Any, Dict, List, Optional
 
 from .message_templates import MessageTemplates
 
 from ..datasources.dexscreener import DexScreenerSource
+from ..database.connection import Database
 from ..telegram_bot.bot import TelegramBot
 
 
@@ -12,14 +14,20 @@ class PerformanceTracker:
     """Track and report performance of tokens."""
 
     def __init__(
-        self, dexscreener: DexScreenerSource, bot: TelegramBot, chat_id: int
+        self,
+        dexscreener: DexScreenerSource,
+        bot: TelegramBot,
+        chat_id: int,
+        database: Optional["Database"] = None,
     ) -> None:
         self.dexscreener = dexscreener
         self.bot = bot
         self.chat_id = chat_id
+        self.database = database
         self.tokens: Dict[str, Dict[str, Any]] = {}
         self.calls = 0
         self.calls_2x = 0
+        self.logger = logging.getLogger(__name__)
 
     def track(self, token: Dict[str, Any]) -> None:
         """Start tracking a token's performance."""
@@ -31,11 +39,18 @@ class PerformanceTracker:
             "hit_2x": False,
         }
         self.calls += 1
+        self.logger.info("Started tracking %s", token.get("name") or token["address"])
 
     async def update(self) -> None:
         """Send performance updates."""
         for addr, info in self.tokens.items():
             data = self.dexscreener.fetch_token_data(addr)
+            pair = self.dexscreener.get_raydium_pair(data)
+            if pair and not info["token"].get("raydium_pair"):
+                info["token"]["raydium_pair"] = pair
+                self.logger.info("Token %s graduated with pair %s", addr, pair)
+                if self.database:
+                    self.database.update_token(addr, {"raydium_pair": pair})
             price = data.get("price", {}).get("usd", 0.0)
             info["highest_price"] = max(info["highest_price"], price)
             token_name = info["token"].get("name") or addr
@@ -49,6 +64,10 @@ class PerformanceTracker:
                         details=f"Hit 2x at ${price}",
                     ),
                 )
+                if self.database:
+                    self.database.get_collection("tokens").update_one(
+                        {"address": addr}, {"$push": {"status_history": "hit_2x"}}
+                    )
 
     def get_stats(self) -> Dict[str, Any]:
         """Return aggregated performance statistics."""

--- a/super_glitch_bot/telegram_bot/bot.py
+++ b/super_glitch_bot/telegram_bot/bot.py
@@ -1,5 +1,6 @@
 """Telegram bot implementation."""
 
+import logging
 from typing import Any, Optional
 
 from telegram.ext import (
@@ -18,6 +19,7 @@ class TelegramBot:
         self.token = token
         self.manager = manager
         self.app: Optional[Application] = None
+        self.logger = logging.getLogger(__name__)
 
     async def run(self) -> None:
         """Start the Telegram bot and run until stopped."""
@@ -32,6 +34,7 @@ class TelegramBot:
         self.app.bot_data["manager"] = self.manager
 
         await self.app.initialize()
+        self.logger.info("Telegram bot starting")
         await self.app.start()
         await self.app.updater.start_polling()
         await self.app.updater.idle()
@@ -40,4 +43,5 @@ class TelegramBot:
         """Send a plain text message."""
         if not self.app:
             raise RuntimeError("Bot not started")
+        self.logger.info("Sending message to %s: %s", chat_id, text)
         await self.app.bot.send_message(chat_id=chat_id, text=text)

--- a/tests/test_assessor.py
+++ b/tests/test_assessor.py
@@ -1,0 +1,27 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+from super_glitch_bot.services.assessor import TokenAssessor
+
+
+def test_assessor_passes():
+    assessor = TokenAssessor()
+    token = {
+        "address": "abc",
+        "rugcheck_report": {"score": 70},
+        "dexscreener_data": {"liquidity": {"usd": 2000}},
+    }
+    assert assessor.assess(token) is True
+
+
+def test_assessor_fails_low_score():
+    assessor = TokenAssessor()
+    token = {
+        "address": "abc",
+        "rugcheck_report": {"score": 50},
+        "dexscreener_data": {"liquidity": {"usd": 2000}},
+    }
+    assert assessor.assess(token) is False

--- a/tests/test_performance_tracker.py
+++ b/tests/test_performance_tracker.py
@@ -1,0 +1,56 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from unittest.mock import AsyncMock
+from super_glitch_bot.services.performance_tracker import PerformanceTracker
+
+
+class FakeDex:
+    def __init__(self, response):
+        self.response = response
+        self.calls = 0
+
+    def fetch_token_data(self, address):
+        self.calls += 1
+        return self.response
+
+    def get_raydium_pair(self, data):
+        return data.get("raydium_pair")
+
+
+class FakeBot:
+    async def send_message(self, chat_id, text):
+        pass
+
+
+class FakeDB:
+    def __init__(self):
+        self.updates = []
+
+    def update_token(self, address, updates):
+        self.updates.append((address, updates))
+
+    def get_collection(self, name):
+        class Coll:
+            def update_one(self, *args, **kwargs):
+                pass
+
+        return Coll()
+
+
+def test_pair_update_and_tracking():
+    dex_data = {"price": {"usd": 1.0}, "raydium_pair": "pair123"}
+    dex = FakeDex(dex_data)
+    bot = FakeBot()
+    db = FakeDB()
+    tracker = PerformanceTracker(dex, bot, chat_id=1, database=db)
+    token = {"address": "token1", "dexscreener_data": dex_data}
+    tracker.track(token)
+    assert "token1" in tracker.tokens
+
+    import asyncio
+
+    asyncio.run(tracker.update())
+    assert db.updates[0] == ("token1", {"raydium_pair": "pair123"})


### PR DESCRIPTION
## Summary
- add fields to `Token` model for lifecycle management
- add update utilities and logging for MongoDB connection
- detect Raydium pair and update database
- log major events across the services and telegram bot
- unit tests for token assessment and performance tracker

## Testing
- `black -l 88 .`
- `pytest -q`
- `python main.py` *(fails: pymongo ConfigurationError)*

------
https://chatgpt.com/codex/tasks/task_e_687ddc42b848832abf89f8c159a4b6b1