### PR TITLE
Implement Bonk token detection

### DIFF
--- a/super_glitch_bot/datasources/bonk.py
+++ b/super_glitch_bot/datasources/bonk.py
@@ -1,14 +1,21 @@
-"""BonkBOT program integration using Helius logs."""
+"""BonkBOT program integration using Helius logs.
 
-from typing import Any, Dict, Optional, Awaitable, Callable
+This source listens for the BonkBot program and detects new token mints.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any, Awaitable, Callable, Dict, Optional
 
 from .helius import HeliusSource
 
 
 class BonkSource(HeliusSource):
-    """Detect new tokens created via bonk."""
+    """Detect new tokens created via BonkBot."""
 
     PROGRAM_ID = "LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj"
+    INIT_VARIANT = 0
 
     def __init__(
         self, rpc_url: str, on_token: Optional[Callable[[str], Awaitable[None]]] = None
@@ -22,5 +29,26 @@ class BonkSource(HeliusSource):
             mint = info.get("mint") or info.get("tokenMint")
             self.logger.debug("Bonk initialize instruction info=%s", info)
             return mint
-        self.logger.debug("Bonk ignored instruction %s", parsed)
-        return None
+
+        if instruction.get("programId") != self.PROGRAM_ID:
+            return None
+
+        data_b64 = instruction.get("data")
+        if not data_b64:
+            self.logger.debug("Bonk instruction missing data")
+            return None
+
+        try:
+            raw = base64.b64decode(data_b64)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.debug("Bonk failed to decode data: %s", exc)
+            return None
+
+        if not raw or raw[0] != self.INIT_VARIANT:
+            self.logger.debug("Bonk unknown instruction variant")
+            return None
+
+        accounts = instruction.get("accounts", [])
+        mint = accounts[1] if len(accounts) > 1 else None
+        self.logger.debug("Bonk initialize via raw data accounts=%s", accounts)
+        return mint

--- a/tests/test_bonk_source.py
+++ b/tests/test_bonk_source.py
@@ -1,0 +1,26 @@
+import base64
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from super_glitch_bot.datasources.bonk import BonkSource
+
+
+def test_parse_bonk_parsed_instruction():
+    source = BonkSource("ws")
+    instruction = {
+        "parsed": {"type": "initialize", "info": {"mint": "mint123"}},
+    }
+    assert source.parse_instruction(instruction) == "mint123"
+
+
+def test_parse_bonk_raw_instruction():
+    source = BonkSource("ws")
+    raw = bytes([BonkSource.INIT_VARIANT]) + b"\0" * 32
+    instruction = {
+        "programId": BonkSource.PROGRAM_ID,
+        "data": base64.b64encode(raw).decode(),
+        "accounts": ["creator", "mintABC"],
+    }
+    assert source.parse_instruction(instruction) == "mintABC"


### PR DESCRIPTION
## Summary
- add BonkSource detection using init variant 0
- include fallback decoding for raw instructions
- test BonkSource parsing with parsed and raw instruction data

## Testing
- `pip install -r requirements.txt`
- `python main.py` *(fails: Empty host (or extra comma in host list))*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4742907c832a9fd96925fc1499e8