### PR TITLE
Add ProgramHeliusSource abstraction

### DIFF
--- a/super_glitch_bot/datasources/__init__.py
+++ b/super_glitch_bot/datasources/__init__.py
@@ -1,6 +1,7 @@
 """Data source package exports."""
 
 from .helius import HeliusSource
+from .helius_program import ProgramHeliusSource
 from .pumpfun import PumpFunSource
 from .bonk import BonkSource
 from .dexscreener import DexScreenerSource
@@ -9,6 +10,7 @@ from .birdeye import BirdEyeSource
 
 __all__ = [
     "HeliusSource",
+    "ProgramHeliusSource",
     "PumpFunSource",
     "BonkSource",
     "DexScreenerSource",

--- a/super_glitch_bot/datasources/bonk.py
+++ b/super_glitch_bot/datasources/bonk.py
@@ -1,26 +1,51 @@
 """BonkBOT program integration using Helius logs."""
 
-from typing import Any, Dict, Optional, Awaitable, Callable
+from __future__ import annotations
 
-from .helius import HeliusSource
+import base64
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from .helius_program import ProgramHeliusSource
 
 
-class BonkSource(HeliusSource):
-    """Detect new tokens created via bonk."""
+class BonkSource(ProgramHeliusSource):
+    """Detect new tokens created via BonkBot."""
 
     PROGRAM_ID = "LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj"
+
+    INIT_VARIANT = 0
 
     def __init__(
         self, rpc_url: str, on_token: Optional[Callable[[str], Awaitable[None]]] = None
     ) -> None:
-        super().__init__(rpc_url, [self.PROGRAM_ID], on_token)
+        def decoder(ix: Dict[str, Any]) -> Optional[str]:
+            if ix.get("programId") != self.PROGRAM_ID:
+                return None
 
-    def parse_instruction(self, instruction: Dict[str, Any]) -> Optional[str]:
-        parsed = instruction.get("parsed")
-        if parsed and parsed.get("type") == "initialize":
-            info = parsed.get("info", {})
-            mint = info.get("mint") or info.get("tokenMint")
-            self.logger.debug("Bonk initialize instruction info=%s", info)
+            data_b64 = ix.get("data")
+            if not data_b64:
+                self.logger.debug("Bonk instruction missing data")
+                return None
+
+            try:
+                raw = base64.b64decode(data_b64)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.logger.debug("Bonk failed to decode data: %s", exc)
+                return None
+
+            if not raw or raw[0] != self.INIT_VARIANT:
+                self.logger.debug("Bonk unknown instruction variant")
+                return None
+
+            accounts = ix.get("accounts", [])
+            mint = accounts[1] if len(accounts) > 1 else None
+            self.logger.debug("Bonk initialize via raw data accounts=%s", accounts)
             return mint
-        self.logger.debug("Bonk ignored instruction %s", parsed)
-        return None
+
+        super().__init__(
+            rpc_url,
+            self.PROGRAM_ID,
+            parsed_type="initialize",
+            decoder=decoder,
+            on_token=on_token,
+        )

--- a/super_glitch_bot/datasources/helius_program.py
+++ b/super_glitch_bot/datasources/helius_program.py
@@ -1,0 +1,82 @@
+"""Program-specific Helius data source."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+import websockets
+
+from .helius import HeliusSource
+
+
+class ProgramHeliusSource(HeliusSource):
+    """Helius source for a specific program."""
+
+    def __init__(
+        self,
+        rpc_url: str,
+        program_id: str,
+        parsed_type: Optional[str] = None,
+        decoder: Optional[Callable[[Dict[str, Any]], Optional[str]]] = None,
+        on_token: Optional[Callable[[str], Awaitable[None]]] = None,
+    ) -> None:
+        super().__init__(rpc_url, [program_id], on_token)
+        self.program_id = program_id
+        self.parsed_type = parsed_type
+        self.decoder = decoder
+
+    def parse_instruction(self, instruction: Dict[str, Any]) -> Optional[str]:
+        if instruction.get("programId") not in (None, self.program_id):
+            return None
+
+        if self.parsed_type:
+            parsed = instruction.get("parsed")
+            if parsed and parsed.get("type") == self.parsed_type:
+                info = parsed.get("info", {})
+                mint = info.get("mint") or info.get("tokenMint")
+                self.logger.debug(
+                    "Parsed %s instruction info=%s", self.parsed_type, info
+                )
+                return mint
+            if parsed is not None:
+                self.logger.debug("Ignored instruction %s", parsed)
+
+        if self.decoder:
+            try:
+                mint = self.decoder(instruction)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.logger.exception("Decode failed: %s", exc)
+                return None
+            if mint:
+                self.logger.debug("Decoded raw instruction to mint %s", mint)
+            return mint
+        return None
+
+    async def _listen(self) -> None:
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "logsSubscribe",
+            "params": [
+                {"mentions": [self.program_id]},
+                {"commitment": "processed"},
+            ],
+        }
+
+        async with websockets.connect(self.rpc_url) as ws:
+            self.logger.info("Listening to Helius WebSocket %s", self.rpc_url)
+            self.logger.debug("Subscribing to program %s", self.program_id)
+            await ws.send(json.dumps(request))
+            while True:
+                message = await ws.recv()
+                data = json.loads(message)
+                if data.get("method") != "logsNotification":
+                    continue
+
+                instructions = data["params"]["result"]["value"].get("instructions", [])
+                for ix in instructions:
+                    mint = self.parse_instruction(ix)
+                    if mint and self.on_token:
+                        self.logger.debug("Detected new token %s", mint)
+                        await self.on_token(mint)

--- a/super_glitch_bot/datasources/pumpfun.py
+++ b/super_glitch_bot/datasources/pumpfun.py
@@ -1,11 +1,11 @@
 """Pump.fun program integration using Helius logs."""
 
-from typing import Any, Dict, Optional, Awaitable, Callable
+from typing import Awaitable, Callable, Optional
 
-from .helius import HeliusSource
+from .helius_program import ProgramHeliusSource
 
 
-class PumpFunSource(HeliusSource):
+class PumpFunSource(ProgramHeliusSource):
     """Detect new tokens created via pump.fun."""
 
     PROGRAM_ID = "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"
@@ -13,14 +13,9 @@ class PumpFunSource(HeliusSource):
     def __init__(
         self, rpc_url: str, on_token: Optional[Callable[[str], Awaitable[None]]] = None
     ) -> None:
-        super().__init__(rpc_url, [self.PROGRAM_ID], on_token)
-
-    def parse_instruction(self, instruction: Dict[str, Any]) -> Optional[str]:
-        parsed = instruction.get("parsed")
-        if parsed and parsed.get("type") == "Create":
-            info = parsed.get("info", {})
-            mint = info.get("mint") or info.get("tokenMint")
-            self.logger.debug("Pump.fun Create instruction info=%s", info)
-            return mint
-        self.logger.debug("Pump.fun ignored instruction %s", parsed)
-        return None
+        super().__init__(
+            rpc_url,
+            self.PROGRAM_ID,
+            parsed_type="Create",
+            on_token=on_token,
+        )

--- a/tests/test_bonk_source.py
+++ b/tests/test_bonk_source.py
@@ -1,0 +1,35 @@
+import base64
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from super_glitch_bot.datasources.bonk import BonkSource
+
+
+def test_parse_bonk_parsed_instruction():
+    source = BonkSource("ws")
+    instruction = {
+        "parsed": {"type": "initialize", "info": {"mint": "mint123"}},
+    }
+    assert source.parse_instruction(instruction) == "mint123"
+
+
+def test_parse_bonk_raw_instruction():
+    source = BonkSource("ws")
+    raw = bytes([BonkSource.INIT_VARIANT]) + b"\0" * 32
+    instruction = {
+        "programId": BonkSource.PROGRAM_ID,
+        "data": base64.b64encode(raw).decode(),
+        "accounts": ["creator", "mintABC"],
+    }
+    assert source.parse_instruction(instruction) == "mintABC"
+
+
+def test_bonk_ignores_other_program():
+    source = BonkSource("ws")
+    instruction = {
+        "programId": "other",
+        "parsed": {"type": "initialize", "info": {"mint": "mint123"}},
+    }
+    assert source.parse_instruction(instruction) is None

--- a/tests/test_helius_program.py
+++ b/tests/test_helius_program.py
@@ -1,0 +1,52 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from super_glitch_bot.datasources.helius_program import ProgramHeliusSource
+
+
+def test_parse_with_parsed_type():
+    source = ProgramHeliusSource("ws://", "pid", parsed_type="Create")
+    instruction = {"parsed": {"type": "Create", "info": {"mint": "mint1"}}}
+    assert source.parse_instruction(instruction) == "mint1"
+
+
+def test_parse_with_decoder():
+    calls = []
+
+    def decoder(ix: dict):
+        calls.append(ix)
+        return "mint2"
+
+    source = ProgramHeliusSource("ws://", "pid", decoder=decoder)
+    instruction = {"data": "abc"}
+    assert source.parse_instruction(instruction) == "mint2"
+    assert calls == [instruction]
+
+
+def test_parse_with_fallback_to_decoder():
+    calls = []
+
+    def decoder(ix: dict):
+        calls.append(ix)
+        return "mint3"
+
+    source = ProgramHeliusSource(
+        "ws://",
+        "pid",
+        parsed_type="Create",
+        decoder=decoder,
+    )
+    instruction = {"data": "def"}
+    assert source.parse_instruction(instruction) == "mint3"
+    assert calls == [instruction]
+
+
+def test_parse_ignores_other_program_id():
+    source = ProgramHeliusSource("ws://", "pid", parsed_type="Create")
+    instruction = {
+        "programId": "other",
+        "parsed": {"type": "Create", "info": {"mint": "mintX"}},
+    }
+    assert source.parse_instruction(instruction) is None


### PR DESCRIPTION
## Summary
- reintroduce `ProgramHeliusSource` for subscribing to program logs
- base class supports parsed instructions or custom decoders
- update `PumpFunSource` and `BonkSource` to use the new class
- include unit tests for generic behaviour and Bonk-specific decoding

## Testing
- `pip install -r requirements.txt`
- `python main.py` *(fails: pymongo.errors.ConfigurationError: Empty host (or extra comma in host list))*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e4e4d034c832ab6df43fa1e68cdcc