### PR TITLE
Improve chart generation with Moralis data

### DIFF
--- a/super_glitch_bot/config.yml
+++ b/super_glitch_bot/config.yml
@@ -14,3 +14,4 @@ helius:
   ws_url: "wss://mainnet.helius-rpc.com"
 assessment_interval: 120
 performance_interval: 120
+moralis_api_key: "${MORALIS_API_KEY}"

--- a/super_glitch_bot/services/chart_generator.py
+++ b/super_glitch_bot/services/chart_generator.py
@@ -61,7 +61,7 @@ class ChartGenerator:
                 try:
                     img = self._circular_logo(logo_url)
                     fig.figimage(img, 10, fig.bbox.ymax - img.size[1] - 10)
-                except Exception:
+                except (requests.RequestException, PIL.UnidentifiedImageError):
                     pass
             fig.savefig(tmp.name)
             plt.close(fig)

--- a/super_glitch_bot/services/chart_generator.py
+++ b/super_glitch_bot/services/chart_generator.py
@@ -1,10 +1,81 @@
 """Generate charts for tokens."""
 
+from __future__ import annotations
+
+import os
+from tempfile import NamedTemporaryFile
+from typing import List, Optional, Sequence
+
+import io
+import requests
+from PIL import Image, ImageDraw
+from ..config import load_config
+
+import matplotlib.pyplot as plt
+
 
 class ChartGenerator:
     """Create charts to include in messages."""
 
-    def generate(self, token_address: str, data: list) -> str:
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self._temp_files: List[str] = []
+        cfg = load_config()
+        self.api_key = api_key or cfg.get("moralis_api_key", "")
+
+    def _fetch_ohlc(self, token_address: str) -> Sequence[float]:
+        url = (
+            "https://solana-gateway.moralis.io/token/mainnet/pairs/"
+            f"{token_address}/ohlcv"
+        )
+        params = {"timeframe": "1min", "limit": 20, "currency": "usd"}
+        headers = {"accept": "application/json", "X-API-Key": self.api_key}
+        response = requests.get(url, headers=headers, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        result = data.get("result", [])
+        closes = [item.get("close", 0.0) for item in result]
+        return closes
+
+    def _circular_logo(self, url: str, size: int = 48) -> Image.Image:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        img = Image.open(io.BytesIO(response.content)).convert("RGBA")
+        img = img.resize((size, size), Image.LANCZOS)
+        mask = Image.new("L", (size, size), 0)
+        draw = ImageDraw.Draw(mask)
+        draw.ellipse((0, 0, size, size), fill=255)
+        img.putalpha(mask)
+        return img
+
+    def generate(self, token_address: str, logo_url: Optional[str] = None) -> str:
         """Return path to generated chart image."""
-        # TODO: implement chart generation
-        raise NotImplementedError
+        closes = self._fetch_ohlc(token_address)
+        with NamedTemporaryFile(delete=False, suffix=".png") as tmp:
+            fig, ax = plt.subplots()
+            ax.plot(closes, color="tab:blue")
+            ax.set_title(f"{token_address} Market Cap")
+            ax.set_xlabel("index")
+            ax.set_ylabel("USD")
+            fig.tight_layout()
+            if logo_url:
+                try:
+                    img = self._circular_logo(logo_url)
+                    fig.figimage(img, 10, fig.bbox.ymax - img.size[1] - 10)
+                except Exception:
+                    pass
+            fig.savefig(tmp.name)
+            plt.close(fig)
+            self._temp_files.append(tmp.name)
+            return tmp.name
+
+    def cleanup(self) -> None:
+        """Remove generated temporary files."""
+        for path in self._temp_files:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+        self._temp_files = []
+
+    def __del__(self) -> None:  # pragma: no cover - cleanup on GC
+        self.cleanup()

--- a/tests/test_chart_generator.py
+++ b/tests/test_chart_generator.py
@@ -1,0 +1,21 @@
+import pathlib
+import sys
+import os
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from super_glitch_bot.services.chart_generator import ChartGenerator
+
+
+def test_generate_creates_image_and_cleans_up(monkeypatch):
+    gen = ChartGenerator(api_key="k")
+
+    def fake_fetch(_addr):
+        return [1, 2, 3, 4]
+
+    monkeypatch.setattr(gen, "_fetch_ohlc", fake_fetch)
+
+    path = gen.generate("token")
+    assert os.path.exists(path)
+    gen.cleanup()
+    assert not os.path.exists(path)


### PR DESCRIPTION
## Summary
- add `moralis_api_key` to config
- implement `ChartGenerator` to fetch OHLC from Moralis, overlay circular token logo, and store temp files
- update chart generator tests for new API

## Testing
- `pip install -r requirements.txt`
- `python main.py` *(fails: ConfigurationError: The DNS query name does not exist)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea938aa2c832aa953e7147d53b079